### PR TITLE
Example Added: Log Normal Shadowing Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ Use `Ctrl + C` to exit the script.
 python bluetooth_scanner.py
 ```
 
+### lnsm.py (Log Normal Shadowing Model)
+
+An example script to scan & output the distance between two bluetooth devices using the RSSI value . The distance between the two devices is calculated using the Log-Normal Shadowing Model/Log-Distance Pathloss Model.
+
+Use `Ctrl + C` to exit the script or wait until number of loops has finished. Recommended number of loops = 30
+
+```
+python lnsm.py <bluetooth-address> [number-of-loops]
+```
+
 ## Notes
 
 * The RSSI values returned will differ depending on your Bluetooth devices and your surroundings (e.g. are there walls/obstructions, multiple floors, etc). 

--- a/examples/lnsm/README.md
+++ b/examples/lnsm/README.md
@@ -1,0 +1,24 @@
+# Log Normal Shadowing Model
+Python code for getting the static distance between bluetooth devices using the RSSI value.
+
+RSSI is measured in dBm but is in its raw form not really useful in an application (apart from being a diagnostic measurement). 
+The nice thing about RSSI is that we can translate the measurements to distance estimates in meters or centimeters. 
+We can describe the relation between RSSI and distance using a model, the Log Normal Shadowing Model/ Log Distance Pathloss Model.
+
+### x = (RSSI_value-A0)/(-10*n)        
+### distance = ((10^x) * 100) + c
+
+A0 = Average RSSI value measured at a distance of 1m from  the transmitting device.
+
+n = Signal Propagation Exponent. It is a constant that differs from environment to environment (0<n<5).
+
+c = Environment Constant. It is a weight added to the distance inorder to reduce the error. It is a constant that differs from environment to environment.
+
+actual_dist = The static distance between the two bluetooth devices during measurement. This value is equal to the distance between the bluetooth devices. E.g: If the distance between the two devices is 20cm, the actual_dist = 20.
+
+You must first measure the avearge value of RSSI(A0) at 1m from the device. After this you must adjust the values of n & c to reduce the error.
+In the example, the values of A0,n & c have been configured to work with a Motorola G4 Plus as the measured bluetooth device. Hence depending upon the bluetooth device being measured, the values of A0,n & c will change respectively.
+
+Following our model, in an ideal world, the RSSI value is only dependent on the distance between the two devices.
+In reality, however, RSSI values are heavily influenced by the environment and have, consequently, high levels of noise. This noise is, for example, caused by multi-path reflections: signals bounce against objects in the environment such as walls and furniture.
+So, we need to fight the noise. Here Kalman filters come in to play. The Kalman filter is a state estimator that makes an estimate of some unobserved variable based on noisy measurements.

--- a/examples/lnsm/lnsm.py
+++ b/examples/lnsm/lnsm.py
@@ -1,0 +1,56 @@
+from bt_proximity import BluetoothRSSI
+import time
+import sys
+import math
+
+BT_ADDR = ''  # You can put your Bluetooth address here.  E.g: 'a4:70:d6:7d:ee:00' 
+NUM_LOOP = 30
+
+def print_usage():
+    print "Usage: python test_address.py <bluetooth-address> [number-of-requests]"
+
+
+def main():
+    if len(sys.argv) > 1:
+        addr = sys.argv[1]
+    elif BT_ADDR:
+        addr = BT_ADDR
+    else:
+        print_usage()
+        return
+    if len(sys.argv) == 3:
+        num = int(sys.argv[2])
+    else:
+        num = NUM_LOOP
+    btrssi = BluetoothRSSI(addr=addr)
+    
+    n=1.5    #Path loss exponent(n) = 1.5
+    c = 10   #Environment constant(C) = 10
+    A0 = 2   #Average RSSI value at d0
+    actual_dist = 37   #Static distance between transmitter and Receiver in cm
+    sum_error = 0
+    count = 0
+    
+    for i in range(1, num):
+        rssi_bt = float(btrssi.get_rssi())
+        if(rssi_bt!=0 and i>10):                    #reduces initial false values of RSSI using initial delay of 10sec
+            count=count+1
+            x = float((rssi_bt-A0)/(-10*n))         #Log Normal Shadowing Model considering d0 =1m where  
+            distance = (math.pow(10,x) * 100) + c
+            error = abs(actual_dist - distance)
+            sum_error = sum_error + error
+            avg_error = sum_error/count
+            print "Average Error=  " + str(avg_error)
+            print "Error=  " + str(error)
+            print "Approximate Distance:" + str(distance)
+            print "RSSI: " + str(rssi_bt)
+            print "Count: " + str(count)
+            print " "
+        time.sleep(1)
+
+
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
I have added an example which calculates the distance between the two Bluetooth devices using the RSSI value based on the Log Normal Shadowing Model. I observed that the RSSI value would return a 0 after the 30th loop/iteration. Hence I set the default number of loops to 30.